### PR TITLE
feat: styling for active list item

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,69 +1,84 @@
-import {
-  Box,
-  Button,
-  Flex,
-  HStack,
-  Image,
-  UnorderedList,
-  Text,
-  Center,
-  Menu,
-  MenuItem,
-  MenuButton,
-  MenuList,
-  Icon
-} from '@chakra-ui/react';
+import { Box, Button, Flex, HStack, Image, UnorderedList, Text, Center, Menu, MenuItem, MenuButton, MenuList, Icon, As } from '@chakra-ui/react';
 import Link from 'next/link';
-import React, { ReactNode, useState } from 'react';
-import {MdAssuredWorkload, MdShoppingBag, MdMap, MdNewspaper, MdRocketLaunch, MdLogin} from 'react-icons/md'
+import React, { useState } from 'react';
+import { MdAssuredWorkload, MdShoppingBag, MdMap, MdNewspaper, MdRocketLaunch, MdLogin } from 'react-icons/md';
+import { useRouter } from 'next/router';
 
-const MobLiItem = ({ children }: { children: ReactNode }) => {
+interface LiItemProps {
+  href: string;
+  itemName: string;
+  itemIcon?: As;
+}
+
+const MobLiItem = ({ href, itemIcon, itemName }: LiItemProps) => {
+  const router = useRouter();
+  const activeRoute = (routeName: string) => {
+    return router.pathname.includes(routeName);
+  };
+
   return (
-    <MenuItem
-      my='4px'
-      bg='transparent'
-      pos='relative'
-      _hover={{
-        color: 'yellow.5',
-        _after: { height: '100%' }
-      }}
-      _after={{
-        content: '""',
-        display: 'block',
-        width: '2px',
-        background: 'yellow.5',
-        position: 'absolute',
-        left: 0
-      }}
-    >
-      <HStack spacing={2}>{children}</HStack>
-    </MenuItem>
+    <Link href={href}>
+      <MenuItem
+        my='4px'
+        bg='transparent'
+        pos='relative'
+        color={activeRoute(href) ? 'yellow.5' : '#ffffff'}
+        _hover={{
+          color: 'yellow.5',
+          _after: { height: '100%' }
+        }}
+        _after={{
+          content: '""',
+          display: 'block',
+          width: '2px',
+          height: activeRoute(href) ? '100%' : 0,
+          background: 'yellow.5',
+          position: 'absolute',
+          left: 0
+        }}
+      >
+        <HStack spacing={2}>
+          <Box>
+            <Icon w={6} h={6} as={itemIcon} />
+          </Box>
+          <Text>{itemName}</Text>
+        </HStack>
+      </MenuItem>
+    </Link>
   );
 };
 
-const DeskLiItem = ({ children }: { children: ReactNode }) => {
+const DeskLiItem = ({ href, itemName }: LiItemProps) => {
+  const router = useRouter();
+  const activeRoute = (routeName: string) => {
+    return router.pathname.includes(routeName);
+  };
+
   return (
-    <HStack
-      pos='relative'
-      _hover={{
-        color: 'yellow.5',
-        transition: 'width 0.3s',
-        _after: { width: '100%' }
-      }}
-      _after={{
-        content: '""',
-        display: 'block',
-        width: 0,
-        height: '2px',
-        background: 'yellow.5',
-        transition: 'width .3s',
-        position: 'absolute',
-        bottom: 0,
-        left: 0
-      }}
-    >
-      <Text>{children}</Text>
-    </HStack>
+    <Link href={href}>
+      <HStack
+        pos='relative'
+        color={activeRoute(href) ? 'yellow.5' : '#ffffff'}
+        _hover={{
+          color: 'yellow.5',
+          transition: 'width 0.3s',
+          _after: { width: '100%' }
+        }}
+        _after={{
+          content: '""',
+          display: 'block',
+          width: activeRoute(href) ? '100%' : 0,
+          height: '2px',
+          background: 'yellow.5',
+          transition: 'width .3s',
+          position: 'absolute',
+          bottom: 0,
+          left: 0
+        }}
+      >
+        <Text>{itemName}</Text>
+      </HStack>
+    </Link>
   );
 };
 
@@ -103,44 +118,38 @@ const Navbar = () => {
           <Image src='/images/nav-ekor.png' draggable='false' loading='lazy' />
         </Box>
         <Box zIndex='1000'>
-          <Image
-            src='/images/nav-logo.svg'
-            height={{ base: '38px', lg: '57px' }}
-            draggable='false'
-            loading='lazy'
-          />
+          <Link href='/'>
+            <Image
+              src='/images/nav-logo.svg'
+              height={{ base: '38px', lg: '57px' }}
+              draggable='false'
+              loading='lazy'
+            />
+          </Link>
         </Box>
         <UnorderedList
           listStyleType='none'
           display={{ base: 'none', lg: 'block' }}
         >
           <HStack spacing={{ lg: '27px', xl: '45px' }}>
-            <Link href='/tes'>
-              <DeskLiItem>About Us</DeskLiItem>
-            </Link>
-            <Link href='/'>
-              <DeskLiItem>Merchandise</DeskLiItem>
-            </Link>
-            <Link href='/'>
-              <DeskLiItem>Interactive Map</DeskLiItem>
-            </Link>
-            <Link href='/'>
-              <DeskLiItem>Blog</DeskLiItem>
-            </Link>
+            <DeskLiItem href='/' itemName='About Us' />
+            <DeskLiItem href='/' itemName='Merchandise' />
+            <DeskLiItem href='/' itemName='Interactive Map' />
+            <DeskLiItem href='/' itemName='Blog' />
             <Box onClick={handleLogin}>
               {isLogin ? (
-                <Link href='/'>
+                <Link href=''>
                   <Button variant='solid'>Space Log</Button>
                 </Link>
               ) : (
-                <Link href='/'>
+                <Link href=''>
                   <Button variant='outline'>Login</Button>
                 </Link>
               )}
             </Box>
           </HStack>
         </UnorderedList>
-        <Box display={{ base: 'block', lg: 'none' }} >
+        <Box display={{ base: 'block', lg: 'none' }}>
           <Menu strategy='fixed'>
             <MenuButton
               as={Button}
@@ -166,57 +175,16 @@ const Navbar = () => {
               bgSize='cover'
               border='none'
             >
-              <Link href='/tes'>
-                <MobLiItem>
-                  <Box>
-                    <Icon w={6} h={6} as={MdAssuredWorkload} />
-                  </Box>
-                  <Text>About Us</Text>
-                </MobLiItem>
-              </Link>
-              <Link href='/'>
-                <MobLiItem>
-                  <Box>
-                    <Icon w={6} h={6} as={MdShoppingBag} />
-                  </Box>
-                  <Text>Merchandise</Text>
-                </MobLiItem>
-              </Link>
-              <Link href='/'>
-                <MobLiItem>
-                  <Box>
-                    <Icon w={6} h={6} as={MdMap} />
-                  </Box>
-                  <Text>Interactive Map</Text>
-                </MobLiItem>
-              </Link>
-              <Link href='/'>
-                <MobLiItem>
-                  <Box>
-                    <Icon w={6} h={6} as={MdNewspaper} />
-                  </Box>
-                  <Text>Blog</Text>
-                </MobLiItem>
-              </Link>
+              <MobLiItem href='/' itemName='About Us' itemIcon={MdAssuredWorkload}/>
+              <MobLiItem href='/' itemName='Merchandise' itemIcon={MdShoppingBag}/>
+              <MobLiItem href='/' itemName='Interactive Map' itemIcon={MdMap}/>
+              <MobLiItem href='/' itemName='Blog' itemIcon={MdNewspaper}/>
               <Box onClick={handleLogin}>
-                {isLogin ? (
-                  <Link href='/'>
-                    <MobLiItem>
-                      <Box>
-                        <Icon w={6} h={6} as={MdRocketLaunch} />
-                      </Box>
-                      <Text>Spacelog</Text>
-                    </MobLiItem>
-                  </Link>
+                {isLogin ? 
+                (
+                  <MobLiItem href='/' itemName='Spacelog' itemIcon={MdRocketLaunch}/>
                 ) : (
-                  <Link href='/'>
-                    <MobLiItem>
-                      <Box>
-                        <Icon w={6} h={6} as={MdLogin} />
-                      </Box>
-                      <Text>Login</Text>
-                    </MobLiItem>
-                  </Link>
+                  <MobLiItem href='/' itemName='Login' itemIcon={MdLogin}/>
                 )}
               </Box>
             </MenuList>


### PR DESCRIPTION
## Story/Task
https://www.figma.com/file/mFJRp0msgxM4FzqtkH11H5/Design-System?type=design&node-id=334-280&mode=design&t=AI6kpCVSm5qXFsh0-0

## Summary
- styling for active menu item
- edit some code in DeskLiItem  & MobLiItem component

## Screenshot
1. Desktop: when active
<img width="1680" alt="Screenshot 2023-07-31 at 23 41 51" src="https://github.com/KATITB2023/oskm-info/assets/109773467/e2c0f0b1-c635-4456-a2aa-0dc98fbc686b">

2. Mobile: when active
<img width="785" alt="Screenshot 2023-07-31 at 23 18 58" src="https://github.com/KATITB2023/oskm-info/assets/109773467/c4f47ca3-9363-4b5d-86ca-18958988381b">

3. Desktop: when hover & active 
<img width="1680" alt="Screenshot 2023-07-31 at 23 40 25" src="https://github.com/KATITB2023/oskm-info/assets/109773467/f982f76f-c806-44dc-9ddc-ab77e150ef12">

